### PR TITLE
WIP Camera Shake

### DIFF
--- a/TPC-demo/PlayerBall.gd
+++ b/TPC-demo/PlayerBall.gd
@@ -18,6 +18,8 @@ func _physics_process(_delta):
 	if Input.is_action_pressed("right") :
 		var dir = camera.get_right_direction()
 		apply_central_force(dir * speed)
+	if Input.is_action_just_pressed("camera_shake") :
+		camera.apply_shake()
 
 
 func _unhandled_input(event):

--- a/TPC-demo/PlayerBall.gd
+++ b/TPC-demo/PlayerBall.gd
@@ -19,7 +19,7 @@ func _physics_process(_delta):
 		var dir = camera.get_right_direction()
 		apply_central_force(dir * speed)
 	if Input.is_action_just_pressed("camera_shake") :
-		camera.apply_shake()
+		camera.apply_preset_shake(0)
 
 
 func _unhandled_input(event):

--- a/TPC-demo/TestScene.tscn
+++ b/TPC-demo/TestScene.tscn
@@ -96,10 +96,11 @@ shape = SubResource("SphereShape3D_ji1ja")
 
 [node name="ThirdPersonCamera" parent="RigidBody3D" instance=ExtResource("3_ky3rl")]
 current = true
-mouse_x_sensitiveness = 0.7
+spring_arm_collision_mask = 277
 
 [node name="SpectatorCamera" type="Camera3D" parent="."]
 transform = Transform3D(-4.23762e-08, -0.245274, 0.969454, -1.07212e-08, 0.969454, 0.245274, -1, 7.01661e-14, -4.37114e-08, 47.6874, 17.5263, 0)
+current = true
 
 [node name="Map" type="Node3D" parent="."]
 

--- a/addons/third-person-camera/third_person_camera/CameraShake.gd
+++ b/addons/third-person-camera/third_person_camera/CameraShake.gd
@@ -1,0 +1,62 @@
+extends Node3D
+class_name CameraShaker
+
+# Noise-based camera shaking component.
+
+# Credit to: https://shaggydev.com/2022/02/23/screen-shake-godot/
+# Also see: https://kidscancode.org/godot_recipes/3.x/2d/screen_shake/index.html
+
+# How quickly to move through the noise
+var volatility: float
+# Noise returns values in the range (-1, 1)
+# So this is how much to multiply the returned value by
+var strength: float
+# Multiplier for lerping the shake strength to zero
+var decay_rate: float
+
+@export var camera: Camera3D
+
+@onready var rand := RandomNumberGenerator.new()
+@onready var noise := FastNoiseLite.new()
+
+# Used to keep track of where we are in the noise
+# so that we can smoothly move through it
+var noise_i: float = 0.0
+
+var current_shake_strength: float = 0.0
+
+
+func _ready() -> void:
+	rand.randomize()
+
+	# Sets the noise type.
+	noise.noise_type = FastNoiseLite.TYPE_SIMPLEX
+	# Randomize the generated noise
+	noise.seed = rand.randi()
+	# Frequency affects how quickly the noise changes values
+	# The higher frequency is, the more rapid the changes.
+	noise.frequency = 1.0/2.0
+
+
+func apply_noise_shake() -> void:
+	current_shake_strength = strength
+
+
+func _process(delta: float) -> void:
+	# Fade out the intensity over time
+	current_shake_strength = lerp(current_shake_strength, 0.0, decay_rate * delta)
+
+	var noise_offset: Vector2 = get_noise_offset(delta)
+
+	camera.h_offset = noise_offset.x
+	camera.v_offset = noise_offset.y
+
+
+func get_noise_offset(delta: float) -> Vector2:
+	noise_i += delta * volatility
+	# Set the x values of each call to 'get_noise_2d' to a different value
+	# so that our x and y vectors will be reading from unrelated areas of noise
+	return Vector2(
+		noise.get_noise_2d(1, noise_i) * current_shake_strength,
+		noise.get_noise_2d(100, noise_i) * current_shake_strength,
+	)

--- a/addons/third-person-camera/third_person_camera/CameraShake.gd
+++ b/addons/third-person-camera/third_person_camera/CameraShake.gd
@@ -1,3 +1,4 @@
+@tool
 extends Node3D
 class_name CameraShaker
 

--- a/addons/third-person-camera/third_person_camera/CameraShakePreset.gd
+++ b/addons/third-person-camera/third_person_camera/CameraShakePreset.gd
@@ -1,0 +1,10 @@
+extends Resource
+class_name CameraShakePreset
+
+# How quickly to move through the noise.
+@export var volatility: float
+# Noise returns values in the range (-1, 1)
+# So this is how much to multiply the returned value by
+@export var strength: float
+# Multiplier for lerping the shake strength to zero
+@export var decay_rate: float

--- a/addons/third-person-camera/third_person_camera/ThirdPersonCamera.gd
+++ b/addons/third-person-camera/third_person_camera/ThirdPersonCamera.gd
@@ -103,14 +103,6 @@ func _set_when_ready(node_path : NodePath, property_name : StringName, value : V
 func _ready():
 	_camera.top_level = true
 
-	# NOTE: This triggers the set functions for each of these properties.
-	# This initializes the child node properties to the correct values.
-	spring_arm_collision_mask = spring_arm_collision_mask
-	spring_arm_margin = spring_arm_margin
-	distance_from_pivot = distance_from_pivot
-
-
-
 
 func _physics_process(_delta):
 
@@ -127,7 +119,6 @@ func _physics_process(_delta):
 	_process_horizontal_rotation_input()
 	_update_camera_tilt()
 	_update_camera_horizontal_rotation()
-
 
 
 func tweenCameraToMarker() :

--- a/addons/third-person-camera/third_person_camera/ThirdPersonCamera.gd
+++ b/addons/third-person-camera/third_person_camera/ThirdPersonCamera.gd
@@ -60,22 +60,7 @@ class_name ThirdPersonCamera extends Node3D
 ##
 @export_group("Camera Shake")
 
-# How quickly to move through the noise
-@export var shake_volatility: float = 15.0 :
-	set(value) :
-		shake_volatility = value
-		_set_when_ready(^"CameraShaker", &"volatility", value)
-# Noise returns values in the range (-1, 1)
-# So this is how much to multiply the returned value by
-@export var shake_strength: float = 1.0 :
-	set(value) :
-		shake_strength = value
-		_set_when_ready(^"CameraShaker", &"strength", value)
-# Multiplier for lerping the shake strength to zero
-@export var shake_decay_rate: float = 10.0 :
-	set(value) :
-		shake_decay_rate = value
-		_set_when_ready(^"CameraShaker", &"decay_rate", value)
+@export var shake_presets: Array[CameraShakePreset]
 
 
 # SpringArm3D properties replication
@@ -120,10 +105,6 @@ func _ready():
 
 	# NOTE: This triggers the set functions for each of these properties.
 	# This initializes the child node properties to the correct values.
-	shake_volatility = shake_volatility
-	shake_decay_rate = shake_decay_rate
-	shake_strength = shake_strength
-
 	spring_arm_collision_mask = spring_arm_collision_mask
 	spring_arm_margin = spring_arm_margin
 	distance_from_pivot = distance_from_pivot
@@ -186,8 +167,8 @@ func _update_camera_horizontal_rotation() :
 	_camera.global_rotation.y = -Vector2(0., -1.).angle_to(vect_to_offset_pivot.normalized())
 
 
-func apply_shake() :
-	_camera_shaker.apply_noise_shake()
+func apply_preset_shake(preset_number: int) :
+	_camera_shaker.apply_preset_shake(shake_presets[preset_number])
 
 
 

--- a/addons/third-person-camera/third_person_camera/ThirdPersonCamera.gd
+++ b/addons/third-person-camera/third_person_camera/ThirdPersonCamera.gd
@@ -16,7 +16,6 @@ class_name ThirdPersonCamera extends Node3D
 # This is used to avoid errors in setting new property values
 # for child nodes which haven't been initialized yet.
 var _pending_node_updates: Array[Array] = []
-const TARGET_CHILD_NODES = [^"CameraShaker", ^"RotationPivot/OffsetPivot/CameraSpringArm"]
 const NODE_INDEX: int = 0
 const PROPERTY_NAME_INDEX: int = 1
 const NEW_VALUE_INDEX: int = 2
@@ -227,12 +226,6 @@ func _update_camera_properties() :
 		_camera.environment = environment
 	if _camera.attributes != attributes :
 		_camera.attributes = attributes
-
-
-func _update_camera_shake_properties() :
-	_camera_shaker.volatility = shake_volatility
-	_camera_shaker.strength = shake_strength
-	_camera_shaker.decay_rate = shake_decay_rate
 
 
 func get_camera() :

--- a/addons/third-person-camera/third_person_camera/ThirdPersonCamera.tscn
+++ b/addons/third-person-camera/third_person_camera/ThirdPersonCamera.tscn
@@ -26,7 +26,7 @@ transform = Transform3D(1, 0, 0, 0, 0.939693, 0.34202, 0, -0.34202, 0.939693, 0,
 top_level = true
 
 [node name="OffsetPivot" type="Node3D" parent="RotationPivot"]
-transform = Transform3D(1, -3.9187e-07, 6.47546e-10, 3.94476e-07, 0.999999, 5.66064e-05, -2.27686e-11, -5.68202e-05, 1, 0, 0, 0)
+transform = Transform3D(1, -3.9187e-07, 6.47546e-10, 3.9448e-07, 1, 5.65946e-05, -2.27516e-11, -5.71012e-05, 1, 0, 0, 0)
 
 [node name="CameraSpringArm" type="SpringArm3D" parent="RotationPivot/OffsetPivot"]
 process_priority = 11
@@ -34,7 +34,7 @@ shape = SubResource("SeparationRayShape3D_84uqy")
 spring_length = 10.0
 
 [node name="CameraMarker" type="Marker3D" parent="RotationPivot/OffsetPivot/CameraSpringArm"]
-transform = Transform3D(1, 7.71143e-08, 3.5101e-07, 1.27095e-08, 1, -7.37009e-06, 2.14425e-07, 1.03673e-06, 1, -6.69733e-09, -0.000565967, 10)
+transform = Transform3D(1, 7.7134e-08, 3.5101e-07, 1.27097e-08, 1, -7.15256e-06, 2.14425e-07, 1.01328e-06, 1, -6.69729e-09, -0.000565767, 9.99999)
 
 [node name="PivotDebug" type="MeshInstance3D" parent="RotationPivot/OffsetPivot"]
 visible = false
@@ -45,7 +45,7 @@ script = ExtResource("2_y3uk4")
 camera = NodePath("../Camera")
 
 [node name="Camera" type="Camera3D" parent="."]
-transform = Transform3D(1, 3.21654e-15, -8.83737e-15, 0, 0.939693, 0.34202, 9.40454e-15, -0.34202, 0.939693, -8.83738e-14, 3.4202, 9.39693)
+transform = Transform3D(1, 4.65509e-15, -1.27898e-14, 0, 0.939693, 0.34202, 1.36106e-14, -0.34202, 0.939693, -1.27898e-13, 3.4202, 9.39693)
 top_level = true
 
 [node name="CameraDebug" type="MeshInstance3D" parent="Camera"]

--- a/addons/third-person-camera/third_person_camera/ThirdPersonCamera.tscn
+++ b/addons/third-person-camera/third_person_camera/ThirdPersonCamera.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=7 format=3 uid="uid://wmf2eu0uuhrg"]
+[gd_scene load_steps=9 format=3 uid="uid://wmf2eu0uuhrg"]
 
 [ext_resource type="Script" path="res://addons/third-person-camera/third_person_camera/ThirdPersonCamera.gd" id="1_telmq"]
+[ext_resource type="Resource" uid="uid://8wq0le7mywh4" path="res://addons/third-person-camera/third_person_camera/camera-shake-presets/DefaultCameraShakePreset.tres" id="2_idc07"]
 [ext_resource type="Script" path="res://addons/third-person-camera/third_person_camera/CameraShake.gd" id="2_y3uk4"]
+[ext_resource type="Resource" uid="uid://cn4iinuc23o7j" path="res://addons/third-person-camera/third_person_camera/camera-shake-presets/GentleSway.tres" id="3_iflr8"]
 
 [sub_resource type="SeparationRayShape3D" id="SeparationRayShape3D_84uqy"]
 margin = 1.135
@@ -20,13 +22,14 @@ height = 0.938
 
 [node name="ThirdPersonCamera" type="Node3D"]
 script = ExtResource("1_telmq")
+shake_presets = Array[Resource("res://addons/third-person-camera/third_person_camera/CameraShakePreset.gd")]([ExtResource("2_idc07"), ExtResource("3_iflr8")])
 
 [node name="RotationPivot" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 0.939693, 0.34202, 0, -0.34202, 0.939693, 0, 0, 0)
 top_level = true
 
 [node name="OffsetPivot" type="Node3D" parent="RotationPivot"]
-transform = Transform3D(1, -3.9187e-07, 6.47546e-10, 3.9448e-07, 1, 5.65946e-05, -2.27516e-11, -5.71012e-05, 1, 0, 0, 0)
+transform = Transform3D(1, -3.9187e-07, 6.47546e-10, 3.9448e-07, 0.999999, 5.66064e-05, -2.2744e-11, -5.73893e-05, 1, 0, 0, 0)
 
 [node name="CameraSpringArm" type="SpringArm3D" parent="RotationPivot/OffsetPivot"]
 process_priority = 11
@@ -34,7 +37,7 @@ shape = SubResource("SeparationRayShape3D_84uqy")
 spring_length = 10.0
 
 [node name="CameraMarker" type="Marker3D" parent="RotationPivot/OffsetPivot/CameraSpringArm"]
-transform = Transform3D(1, 7.7134e-08, 3.5101e-07, 1.27097e-08, 1, -7.15256e-06, 2.14425e-07, 1.01328e-06, 1, -6.69729e-09, -0.000565767, 9.99999)
+transform = Transform3D(1, 7.74847e-08, 3.50877e-07, 1.27199e-08, 1.00001, 0.000275159, 2.14423e-07, -4.71756e-08, 1.00147, -6.69726e-09, -0.000565854, 10)
 
 [node name="PivotDebug" type="MeshInstance3D" parent="RotationPivot/OffsetPivot"]
 visible = false
@@ -45,7 +48,7 @@ script = ExtResource("2_y3uk4")
 camera = NodePath("../Camera")
 
 [node name="Camera" type="Camera3D" parent="."]
-transform = Transform3D(1, 4.65509e-15, -1.27898e-14, 0, 0.939693, 0.34202, 1.36106e-14, -0.34202, 0.939693, -1.27898e-13, 3.4202, 9.39693)
+transform = Transform3D(1, 2.13359e-15, -5.86198e-15, 0, 0.939693, 0.34202, 6.23819e-15, -0.34202, 0.939693, -5.86198e-14, 3.4202, 9.39693)
 top_level = true
 
 [node name="CameraDebug" type="MeshInstance3D" parent="Camera"]

--- a/addons/third-person-camera/third_person_camera/ThirdPersonCamera.tscn
+++ b/addons/third-person-camera/third_person_camera/ThirdPersonCamera.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://wmf2eu0uuhrg"]
+[gd_scene load_steps=7 format=3 uid="uid://wmf2eu0uuhrg"]
 
 [ext_resource type="Script" path="res://addons/third-person-camera/third_person_camera/ThirdPersonCamera.gd" id="1_telmq"]
+[ext_resource type="Script" path="res://addons/third-person-camera/third_person_camera/CameraShake.gd" id="2_y3uk4"]
 
 [sub_resource type="SeparationRayShape3D" id="SeparationRayShape3D_84uqy"]
 margin = 1.135
@@ -25,7 +26,7 @@ transform = Transform3D(1, 0, 0, 0, 0.939693, 0.34202, 0, -0.34202, 0.939693, 0,
 top_level = true
 
 [node name="OffsetPivot" type="Node3D" parent="RotationPivot"]
-transform = Transform3D(1, -3.9187e-07, 6.47546e-10, 3.94476e-07, 1, 5.65946e-05, -2.27374e-11, -5.65946e-05, 1, 0, 0, 0)
+transform = Transform3D(1, -3.9187e-07, 6.47546e-10, 3.94476e-07, 0.999999, 5.66064e-05, -2.27686e-11, -5.68202e-05, 1, 0, 0, 0)
 
 [node name="CameraSpringArm" type="SpringArm3D" parent="RotationPivot/OffsetPivot"]
 process_priority = 11
@@ -33,14 +34,18 @@ shape = SubResource("SeparationRayShape3D_84uqy")
 spring_length = 10.0
 
 [node name="CameraMarker" type="Marker3D" parent="RotationPivot/OffsetPivot/CameraSpringArm"]
-transform = Transform3D(1, 7.93401e-08, 3.5101e-07, 1.48521e-08, 1, -7.89762e-06, 2.08538e-07, 1.2219e-06, 1, -6.69741e-09, -0.000566006, 9.99999)
+transform = Transform3D(1, 7.71143e-08, 3.5101e-07, 1.27095e-08, 1, -7.37009e-06, 2.14425e-07, 1.03673e-06, 1, -6.69733e-09, -0.000565967, 10)
 
 [node name="PivotDebug" type="MeshInstance3D" parent="RotationPivot/OffsetPivot"]
 visible = false
 mesh = SubResource("SphereMesh_ag7lb")
 
+[node name="CameraShaker" type="Node3D" parent="." node_paths=PackedStringArray("camera")]
+script = ExtResource("2_y3uk4")
+camera = NodePath("../Camera")
+
 [node name="Camera" type="Camera3D" parent="."]
-transform = Transform3D(1, 5.38245e-15, -1.47882e-14, 0, 0.939693, 0.34202, 1.57372e-14, -0.34202, 0.939693, -1.47882e-13, 3.4202, 9.39693)
+transform = Transform3D(1, 3.21654e-15, -8.83737e-15, 0, 0.939693, 0.34202, 9.40454e-15, -0.34202, 0.939693, -8.83738e-14, 3.4202, 9.39693)
 top_level = true
 
 [node name="CameraDebug" type="MeshInstance3D" parent="Camera"]

--- a/addons/third-person-camera/third_person_camera/ThirdPersonCamera.tscn
+++ b/addons/third-person-camera/third_person_camera/ThirdPersonCamera.tscn
@@ -37,7 +37,7 @@ shape = SubResource("SeparationRayShape3D_84uqy")
 spring_length = 10.0
 
 [node name="CameraMarker" type="Marker3D" parent="RotationPivot/OffsetPivot/CameraSpringArm"]
-transform = Transform3D(1, 7.74847e-08, 3.50877e-07, 1.27199e-08, 1.00001, 0.000275159, 2.14423e-07, -4.71756e-08, 1.00147, -6.69726e-09, -0.000565854, 10)
+transform = Transform3D(1, 7.73591e-08, 3.50877e-07, 1.27424e-08, 1.00001, 0.000275189, 2.14419e-07, -1.01818e-08, 1.00147, -6.69726e-09, -0.000565854, 10)
 
 [node name="PivotDebug" type="MeshInstance3D" parent="RotationPivot/OffsetPivot"]
 visible = false

--- a/addons/third-person-camera/third_person_camera/camera-shake-presets/DefaultCameraShakePreset.tres
+++ b/addons/third-person-camera/third_person_camera/camera-shake-presets/DefaultCameraShakePreset.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="CameraShakePreset" load_steps=2 format=3 uid="uid://8wq0le7mywh4"]
+
+[ext_resource type="Script" path="res://addons/third-person-camera/third_person_camera/CameraShakePreset.gd" id="1_8jha4"]
+
+[resource]
+script = ExtResource("1_8jha4")
+volatility = 15.0
+strength = 1.0
+decay_rate = 10.0

--- a/addons/third-person-camera/third_person_camera/camera-shake-presets/GentleSway.tres
+++ b/addons/third-person-camera/third_person_camera/camera-shake-presets/GentleSway.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="CameraShakePreset" load_steps=2 format=3 uid="uid://cn4iinuc23o7j"]
+
+[ext_resource type="Script" path="res://addons/third-person-camera/third_person_camera/CameraShakePreset.gd" id="1_mgo07"]
+
+[resource]
+script = ExtResource("1_mgo07")
+volatility = 0.1
+strength = 0.5
+decay_rate = 0.1

--- a/project.godot
+++ b/project.godot
@@ -70,6 +70,11 @@ toggle_mouse_mode={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194306,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
+camera_shake={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
+]
+}
 
 [rendering]
 


### PR DESCRIPTION
Adds noise-based camera shake. A camera shake can be started in the TestScene by pressing spacebar.

The shake code itself uses methods that seem to be widely standard in the Godot community. References included in the code.

Below I've detailed the reasoning behind the introduction of the `_pending_node_updates` system.

### Regarding the new array

There's a few weird things in here that I wanted feedback on before going too much further.

I ran into an issue with the new `CameraShaker` node and the existing `SpringArm3D` node which necessitated the creation of the `_pending_node_updates` array. The `ThirdPersonCamera.gd` script provides exports for properties which are defined on children nodes. This allows useful functionality such as allowing editing "inner properties" when the scene is instantiated in other scenes. But it appears that when one sets a non-default value for any of these properties, one of the first things Godot 4.2.1 does on start up is call the set function. This caused an exception due to the child node not being initialized yet.

For example, when I set a non-default value in the editor for the `spring_arm_collision_mask`, a call to the set function was dispatched immediately on start-up. This meant that when it got to the line 

```$RotationPivot/OffsetPivot/CameraSpringArm.collision_mask = value```

The `$` (`get_node`) call would be unable to retrieve a node as the `CameraSpringArm` was not ready yet. Thus an exception would result in attempting to access `collision_mask` on a `nil` object.

The `_pending_node_updates` array was introduced as a way to "defer" the update until `_physics_process` ran. At that point the children nodes would have to be ready, and thus a `get_node` call on their Node path would succeed.

This pattern was further complicated by default values not getting a set call. If the code and the Editor agree, then the Editor has no need to submit set calls on Node start-up. But then this meant that default values would not be pushed down to the children nodes. Thus I added to the _ready function the "identity" assignments like 

`shake_volatility = shake_volatility`

This guarantees a set call at the beginning so that we can push the values down to the sub nodes. (Another option would be to set the defaults of the children nodes to agree with the defaults of the root `ThirdPersonCamera` node. But this introduces a potential source of confusing user error that I wanted to avoid.)

I'm wondering a bit whether I have simply misunderstood something fundamental in Godot about how to set children node properties. Let me know if there's a better way to go about this. 